### PR TITLE
Send link and user with shared media (fixes #10)

### DIFF
--- a/src/instagram.ts
+++ b/src/instagram.ts
@@ -115,9 +115,13 @@ export class Instagram {
 			log.verbose("Got a media share to pass on");
 			const imgUrl = share.image_versions2.candidates[0].url;
 			const params = this.getSendParams(puppetId, msg);
+			const mediaWebUrl = `https://www.instagram.com/p/${share.code}`;
+			const user = share.user.username;
+			const userWebUrl = `http://www.instagram.com/${user}/`;
 
 			await this.puppet.sendMessage(params, {
-				body: "New media has been shared:",
+				body: `New media by ${user} has been shared: ${mediaWebUrl}`,
+				formattedBody: `New media by <a href="${userWebUrl}">${user}</a> has been shared: <a href="${mediaWebUrl}">${mediaWebUrl}</a>`,
 			});
 			await this.puppet.sendFileDetect(params, imgUrl);
 			await this.puppet.sendMessage(params, {


### PR DESCRIPTION
This PR adds a link to the media in the Instagram web app, the username of the creator, and a link to their user page when media is shared.