### PR TITLE
Change to make it compatiable with ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /opt/mx-puppet-instagram
 # run build process as user in case of npm pre hooks
 # pre hooks are not executed while running as root
 RUN chown node:node /opt/mx-puppet-instagram
-RUN apk --no-cache add git python make g++ pkgconfig \
+RUN apk --no-cache add git python3 make g++ pkgconfig \
     build-base \
     cairo-dev \
     jpeg-dev \


### PR DESCRIPTION
The alpine linux does not have a `python` package for the ARM64 version. This is a little change in the dockerfile so it builds with python3, which is present in both versions of the alpine package manager